### PR TITLE
feat: add teacher admin mode with login/logout authentication

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +21,23 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+with open(current_dir / "teachers.json") as f:
+    teachers = json.load(f)
+
+# Active sessions: token -> username
+sessions: dict = {}
+
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_teacher(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Dependency: validates that a teacher is logged in."""
+    if credentials is None or credentials.credentials not in sessions:
+        raise HTTPException(status_code=401, detail="Authentication required. Teachers only.")
+    return sessions[credentials.credentials]
+
 
 # In-memory activity database
 activities = {
@@ -83,14 +103,32 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/login")
+def login(username: str, password: str):
+    """Teacher login — returns a session token"""
+    if username not in teachers or teachers[username] != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    token = secrets.token_hex(32)
+    sessions[token] = username
+    return {"token": token, "username": username}
+
+
+@app.post("/logout")
+def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Teacher logout — invalidates the session token"""
+    if credentials and credentials.credentials in sessions:
+        del sessions[credentials.credentials]
+    return {"message": "Logged out successfully"}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, teacher: str = Depends(get_current_teacher)):
+    """Sign up a student for an activity (teacher login required)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +149,8 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, teacher: str = Depends(get_current_teacher)):
+    """Unregister a student from an activity (teacher login required)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,108 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userIconBtn = document.getElementById("user-icon-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginError = document.getElementById("login-error");
+  const signupContainer = document.getElementById("signup-container");
+
+  // Auth state — persisted in sessionStorage for the browser tab
+  let authToken = sessionStorage.getItem("authToken");
+  let authUsername = sessionStorage.getItem("authUsername");
+
+  function isLoggedIn() {
+    return !!authToken;
+  }
+
+  function updateAuthUI() {
+    if (isLoggedIn()) {
+      userIconBtn.title = `Logged in as ${authUsername} — Click to logout`;
+      userIconBtn.classList.add("logged-in");
+      signupContainer.classList.remove("hidden");
+    } else {
+      userIconBtn.title = "Teacher Login";
+      userIconBtn.classList.remove("logged-in");
+      signupContainer.classList.add("hidden");
+    }
+    fetchActivities();
+  }
+
+  // Toggle login modal or logout on icon click
+  userIconBtn.addEventListener("click", () => {
+    if (isLoggedIn()) {
+      handleLogout();
+    } else {
+      loginModal.classList.remove("hidden");
+      document.getElementById("username").focus();
+    }
+  });
+
+  // Close modal on Cancel button
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+    loginError.classList.add("hidden");
+  });
+
+  // Close modal when clicking outside
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) {
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+      loginError.classList.add("hidden");
+    }
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    try {
+      const response = await fetch(
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+      if (response.ok) {
+        authToken = result.token;
+        authUsername = result.username;
+        sessionStorage.setItem("authToken", authToken);
+        sessionStorage.setItem("authUsername", authUsername);
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        loginError.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginError.textContent = "Login failed. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Handle logout
+  async function handleLogout() {
+    if (authToken) {
+      try {
+        await fetch("/logout", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${authToken}` },
+        });
+      } catch (e) {
+        // Ignore logout errors — clear state regardless
+      }
+    }
+    authToken = null;
+    authUsername = null;
+    sessionStorage.removeItem("authToken");
+    sessionStorage.removeItem("authUsername");
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -10,8 +112,9 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch("/activities");
       const activities = await response.json();
 
-      // Clear loading message
+      // Clear loading message and previous entries
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -21,7 +124,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Show delete buttons only for logged-in teachers
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +133,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +187,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
 
@@ -124,6 +232,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
 
@@ -156,5 +265,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,30 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <button id="user-icon-btn" class="user-icon-btn" title="Teacher Login">👤</button>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter your username" autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter your password" autocomplete="current-password" />
+          </div>
+          <div class="modal-buttons">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login-btn" class="btn-secondary">Cancel</button>
+          </div>
+        </form>
+        <div id="login-error" class="hidden error-msg"></div>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,7 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
@@ -197,4 +198,81 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* ── Teacher login icon in header ── */
+.user-icon-btn {
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  color: white;
+  font-size: 20px;
+  padding: 5px 10px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.user-icon-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: white;
+}
+
+.user-icon-btn.logged-in {
+  background-color: rgba(255, 255, 255, 0.25);
+  border-color: white;
+}
+
+/* ── Login modal overlay ── */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 380px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 5px;
+}
+
+.btn-secondary {
+  background-color: #9e9e9e;
+}
+
+.btn-secondary:hover {
+  background-color: #757575;
+}
+
+.error-msg {
+  margin-top: 12px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background-color: #ffebee;
+  color: #c62828;
+  border: 1px solid #ef9a9a;
+  font-size: 14px;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "mrsmith": "password",
+  "msjones": "teacher123"
+}


### PR DESCRIPTION
## Description

Fixes #5

Students were able to remove each other from activities to free up space for themselves. This PR adds a teacher authentication system to restrict signup and unregister operations to logged-in teachers only.

## Changes

- **`src/teachers.json`** (new): stores teacher usernames and passwords
- **`src/app.py`**: 
  - Added `POST /login` — validates credentials, returns a session token
  - Added `POST /logout` — invalidates the session token
  - Protected `POST /activities/{name}/signup` — teachers only
  - Protected `DELETE /activities/{name}/unregister` — teachers only
  - Students can still view all activities without logging in
- **`src/static/index.html`**: added 👤 icon button in the header + login modal
- **`src/static/app.js`**: manages auth state via `sessionStorage`, hides signup form and ❌ buttons for non-teachers
- **`src/static/styles.css`**: styles for the user icon and login modal overlay

## Behaviour

- **Students (not logged in)**: can browse activities and see participants, but cannot sign up or unregister anyone
- **Teachers (logged in)**: see the signup form and ❌ unregister buttons; clicking the 👤 icon again logs out